### PR TITLE
Optimize encoding parameters for low-latency

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -45,7 +45,7 @@ ping_timeout = 2000
 # The file where configuration for the different applications that Sunshine can run during a stream
 # file_apps = apps.json
 
-# How much error correcting packets must be send for every video max_b_frames
+# How much error correcting packets must be send for every video
 # This is just some random number, don't know the optimal value
 # The higher fec_percentage, the lower space for the actual data to send per frame there is
 fec_percentage = 10
@@ -69,8 +69,6 @@ fec_percentage = 10
 # FFmpeg software encoding parameters
 # Honestly, I have no idea what the optimal values would be.
 # Play around with this :)
-max_b_frames = 4
-gop_size = 24
 
 # Constant Rate Factor. Between 1 and 52. It allows QP to go up during motion and down with still image, resulting in constant perceived quality
 # Higher value means more compression, but less quality

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -14,8 +14,6 @@
 namespace config {
 using namespace std::literals;
 video_t video {
-  16, // max_b_frames
-  24, // gop_size
   35, // crf
   35, // qp
 
@@ -158,8 +156,6 @@ void parse_file(const char *file) {
     std::cout << "["sv << name << "] -- ["sv << val << ']' << std::endl;
   }
 
-  int_f(vars, "max_b_frames", video.max_b_frames);
-  int_f(vars, "gop_size", video.gop_size);
   int_f(vars, "crf", video.crf);
   int_f(vars, "qp", video.qp);
   int_f(vars, "threads", video.threads);

--- a/sunshine/config.h
+++ b/sunshine/config.h
@@ -7,8 +7,6 @@
 namespace config {
 struct video_t {
   // ffmpeg params
-  int max_b_frames;
-  int gop_size;
   int crf; // higher == more compression and less quality
   int qp; // higher == more compression and less quality, ignored if crf != 0
 

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -970,6 +970,7 @@ void cmd_announce(host_t &host, peer_t peer, msg_t &&req) {
     config.monitor.framerate      = util::from_view(args.at("x-nv-video[0].maxFPS"sv));
     config.monitor.bitrate        = util::from_view(args.at("x-nv-vqos[0].bw.maximumBitrateKbps"sv));
     config.monitor.slicesPerFrame = util::from_view(args.at("x-nv-video[0].videoEncoderSlicesPerFrame"sv));
+    config.monitor.numRefFrames   = util::from_view(args.at("x-nv-video[0].maxNumReferenceFrames"sv));
 
   } catch(std::out_of_range &) {
 

--- a/sunshine/video.h
+++ b/sunshine/video.h
@@ -21,6 +21,7 @@ struct config_t {
   int framerate;
   int bitrate;
   int slicesPerFrame;
+  int numRefFrames;
 };
 
 void capture_display(packet_queue_t packets, idr_event_t idr_events, config_t config);


### PR DESCRIPTION
GOP size should be infinite to avoid encoding periodic I-frames that reduce perceived quality due to hitting the bitrate ceiling. Clients will request I-frames when needed, so generating them periodically is unnecessary.

B-frames should be avoided because each B-frame increases decoder output latency by one frame. B-frames weren't actually used in the default configuration because H.264 Baseline doesn't support them. However, attempting to specify the H.264 High profile would cause the encoder to create them.

Additionally, I added support for the `x-nv-video[0].maxNumReferenceFrames` attribute to set the maximum number of reference frames. Some very conservative decoders will even delay output by `num_ref_frames`, so it's important to respect the client's request there.