### PR TITLE
Use hostname as the default Sunshine name

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -8,7 +8,8 @@
 # cert = /dir/cert.pem
 
 # The name displayed by Moonlight
-sunshine_name = Sunshine
+# If not specified, the PC's hostname is used
+# sunshine_name = Sunshine
 
 # The minimum log level printed to standard out
 #

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -3,6 +3,8 @@
 #include <functional>
 #include <unordered_map>
 
+#include <boost/asio.hpp>
+
 #include "utility.h"
 #include "config.h"
 
@@ -41,7 +43,7 @@ nvhttp_t nvhttp {
   PRIVATE_KEY_FILE,
   CERTIFICATE_FILE,
 
-  "sunshine"s, // sunshine_name,
+  boost::asio::ip::host_name(), // sunshine_name,
   "03904e64-51da-4fb3-9afd-a9f7ff70fea4"s, // unique_id
   "devices.json"s // file_devices
 };


### PR DESCRIPTION
With multiple Sunshine hosts on the network, it's useful to have a way of distinguishing them by default. This behavior also mimics what GFE does.