### PR TITLE
Use the default monitor rather than the default source

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -58,7 +58,7 @@ fec_percentage = 10
 # back_button_timeout = 2000
 
 # The name of the audio sink used for Audio Loopback
-# If you do not specify this variable, pulseaudio will select a default device, which could be a microphone instead of a speaker
+# If you do not specify this variable, pulseaudio will select the default monitor device.
 #
 # You can find the name of the audio sink using the following command:
 # pacmd list-sources | grep "name:"

--- a/sunshine/platform/linux.cpp
+++ b/sunshine/platform/linux.cpp
@@ -336,6 +336,9 @@ std::unique_ptr<mic_t> microphone(std::uint32_t sample_rate) {
   if(!config::audio.sink.empty()) {
     audio_sink = config::audio.sink.c_str();
   }
+  else {
+    audio_sink = "@DEFAULT_MONITOR@";
+  }
 
   mic->mic.reset(
     pa_simple_new(nullptr, "sunshine", pa_stream_direction_t::PA_STREAM_RECORD, audio_sink, "sunshine_record", &mic->ss, nullptr, nullptr, &status)


### PR DESCRIPTION
If we create a new PulseAudio recording stream without specifying a device name, PA will assume you want to record from the default source, which is usually a microphone. Fortunately, PA supports some magic device names (`@DEFAULT_SOURCE@`, `@DEFAULT_SINK@`, and `@DEFAULT_MONITOR@`) to indicate what we're looking for.

Using `@DEFAULT_MONITOR@` rather than `nullptr` prevents PA from picking an actual audio input source and should prevent users from having to manually specify the sink in most situations.