### PR TITLE
Add support for HEVC and client-specified colorspaces

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -86,8 +86,13 @@ qp = 28
 # Number of threads used by ffmpeg to encode the video
 threads = 8
 
+# Allows the client to request HEVC Main or HEVC Main10 video streams.
+# HEVC is more CPU-intensive to encode, so enabling this may reduce performance.
+# If set to 0 (default), Sunshine will not advertise support for HEVC
+# If set to 1, Sunshine will advertise support for HEVC Main profile
+# If set to 2, Sunshine will advertise support for HEVC Main and Main10 (HDR) profiles
+# hevc_mode = 2
 
 # See x264 --fullhelp for the different presets
-profile = baseline
 preset  = superfast
 tune    = zerolatency

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -21,7 +21,7 @@ video_t video {
 
   4, // threads
 
-  "baseline"s, // profile
+  0, // hevc_mode
   "superfast"s, // preset
   "zerolatency"s // tune
 };
@@ -158,7 +158,9 @@ void parse_file(const char *file) {
   int_f(vars, "crf", video.crf);
   int_f(vars, "qp", video.qp);
   int_f(vars, "threads", video.threads);
-  string_f(vars, "profile", video.profile);
+  int_between_f(vars, "hevc_mode", video.hevc_mode, {
+    0, 2
+  });
   string_f(vars, "preset", video.preset);
   string_f(vars, "tune", video.tune);
 

--- a/sunshine/config.h
+++ b/sunshine/config.h
@@ -12,7 +12,7 @@ struct video_t {
 
   int threads; // Number threads used by ffmpeg
 
-  std::string profile;
+  int hevc_mode;
   std::string preset;
   std::string tune;
 };

--- a/sunshine/nvhttp.cpp
+++ b/sunshine/nvhttp.cpp
@@ -437,13 +437,21 @@ void serverinfo(std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> res
   tree.put("root.appversion", VERSION);
   tree.put("root.GfeVersion", GFE_VERSION);
   tree.put("root.uniqueid", config::nvhttp.unique_id);
-  tree.put("root.mac", "42:45:F0:65:D6:F4");
+  tree.put("root.mac", "00:00:00:00:00:00");
+  tree.put("root.MaxLumaPixelsHEVC", config::video.hevc_mode > 0 ? "1869449984" : "0");
   tree.put("root.LocalIP", local_ip);
 
-  if(config::nvhttp.external_ip.empty()) {
-    tree.put("root.ExternalIP", local_ip);
+  if(config::video.hevc_mode == 2) {
+    tree.put("root.ServerCodecModeSupport", "3843");
+  }
+  else if(config::video.hevc_mode == 1) {
+    tree.put("root.ServerCodecModeSupport", "259");
   }
   else {
+    tree.put("root.ServerCodecModeSupport", "3");
+  }
+
+  if(!config::nvhttp.external_ip.empty()) {
     tree.put("root.ExternalIP", config::nvhttp.external_ip);
   }
 
@@ -485,7 +493,7 @@ void applist(resp_https_t response, req_https_t request) {
   pt::ptree desktop;
 
   apps.put("<xmlattr>.status_code", 200);
-  desktop.put("IsHdrSupported"s, 0);
+  desktop.put("IsHdrSupported"s, config::video.hevc_mode == 2 ? 1 : 0);
   desktop.put("AppTitle"s, "Desktop");
   desktop.put("ID"s, 1);
 
@@ -493,7 +501,7 @@ void applist(resp_https_t response, req_https_t request) {
   for(auto &proc : proc::proc.get_apps()) {
     pt::ptree app;
 
-    app.put("IsHdrSupported"s, 0);
+    app.put("IsHdrSupported"s, config::video.hevc_mode == 2 ? 1 : 0);
     app.put("AppTitle"s, proc.name);
     app.put("ID"s, x++);
 

--- a/sunshine/video.h
+++ b/sunshine/video.h
@@ -22,6 +22,9 @@ struct config_t {
   int bitrate;
   int slicesPerFrame;
   int numRefFrames;
+  int encoderCscMode;
+  int videoFormat;
+  int dynamicRange;
 };
 
 void capture_display(packet_queue_t packets, idr_event_t idr_events, config_t config);


### PR DESCRIPTION
This PR adds support for encoding in HEVC Main and HEVC Main10 profiles. On my test laptop, the performance of HEVC encoding is worse than H.264, so I left it disabled by default. This work required me to remove the `profile` configuration option, because HEVC and H.264 have different profiles and sometimes they are implied by the client's request (like Main10 for HDR mode). As part of the profile removal, I changed the default H.264 profile from Baseline to High to match what GFE uses.

I also added support for reading the `x-nv-video[0].encoderCscMode` which specifies the client's desired color space and color range. This fixes color conversion issues on some clients (Windows, Steam Link) which were not getting their requested color space and misinterpreting the video data as Rec 709 instead of Rec 601.