### PR TITLE
Support multi-homed hosts and plumb MAC addresses for Linux

### DIFF
--- a/sunshine/nvhttp.cpp
+++ b/sunshine/nvhttp.cpp
@@ -77,7 +77,6 @@ struct pair_session_t {
 std::unordered_map<std::string, pair_session_t> map_id_sess;
 std::unordered_map<std::string, client_t> map_id_client;
 std::string unique_id;
-std::string local_ip;
 net::net_e origin_pin_allowed;
 
 using args_t = SimpleWeb::CaseInsensitiveMultimap;
@@ -442,9 +441,9 @@ void serverinfo(std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> res
   tree.put("root.appversion", VERSION);
   tree.put("root.GfeVersion", GFE_VERSION);
   tree.put("root.uniqueid", unique_id);
-  tree.put("root.mac", "00:00:00:00:00:00");
+  tree.put("root.mac", platf::get_mac_address(request->local_endpoint_address()));
   tree.put("root.MaxLumaPixelsHEVC", config::video.hevc_mode > 0 ? "1869449984" : "0");
-  tree.put("root.LocalIP", local_ip);
+  tree.put("root.LocalIP", request->local_endpoint_address());
 
   if(config::video.hevc_mode == 2) {
     tree.put("root.ServerCodecModeSupport", "3843");
@@ -654,15 +653,7 @@ void appasset(resp_https_t response, req_https_t request) {
 }
 
 void start(std::shared_ptr<safe::event_t<bool>> shutdown_event) {
-  local_ip = platf::get_local_ip();
   origin_pin_allowed = net::from_enum_string(config::nvhttp.origin_pin_allowed);
-
-  if(local_ip.empty()) {
-    BOOST_LOG(fatal) << "Could not determine the local ip-address"sv;
-    log_flush();
-    std::abort();
-  }
-
   load_state();
 
   conf_intern.pkey = read_file(config::nvhttp.pkey.c_str());

--- a/sunshine/platform/common.h
+++ b/sunshine/platform/common.h
@@ -75,7 +75,7 @@ void freeInput(void*);
 
 using input_t = util::safe_ptr<void, freeInput>;
 
-std::string get_local_ip();
+std::string get_mac_address(const std::string_view &address);
 
 std::unique_ptr<mic_t> microphone(std::uint32_t sample_rate);
 std::shared_ptr<display_t> display();

--- a/sunshine/platform/windows.cpp
+++ b/sunshine/platform/windows.cpp
@@ -57,7 +57,9 @@ public:
   client_t client;
 };
 
-std::string get_local_ip() { return "192.168.0.119"s; }
+std::string get_mac_address(const std::string_view &address) {
+  return "00:00:00:00:00:00"s;
+}
 
 input_t input() {
   input_t result { new vigem_t {} };


### PR DESCRIPTION
~~**Note: https://github.com/loki-47-6F-64/Simple-Web-Server/pull/1 needs to be merged and the submodule to be updated for this PR to build!**~~

This PR adds support for multi-homed hosts, so we will now properly report the local IP address corresponding to the actual connection we received. This also makes the reported local IP accurate even if our IP address changes while Sunshine is running.

I've also added support for retrieving the MAC address on Linux, so Wake-on-LAN works with Moonlight clients.