### PR TITLE
Archive Sunshine builds for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,10 @@ else()
 	list(APPEND SUNSHINE_COMPILE_OPTIONS -O3)
 endif()
 
+if(NOT SUNSHINE_ROOT)
+	set(SUNSHINE_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
 		${CMAKE_THREAD_LIBS_INIT}
 		stdc++fs
@@ -128,7 +132,7 @@ list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
 		${Boost_LIBRARIES}
 		${PLATFORM_LIBRARIES})
 
-add_definitions(-DSUNSHINE_ASSETS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/assets")
+add_definitions(-DSUNSHINE_ASSETS_DIR="${SUNSHINE_ROOT}/assets")
 add_executable(sunshine ${SUNSHINE_TARGET_FILES})
 target_link_libraries(sunshine ${SUNSHINE_EXTERNAL_LIBRARIES})
 target_compile_definitions(sunshine PUBLIC ${SUNSHINE_DEFINITIONS})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,16 @@ before_build:
   - cd build
 
 build_script:
+  - cmd: set OLDPATH=%PATH%
   - cmd: set PATH=C:\msys64\mingw64\bin
   - sh: cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-  - cmd: cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64 -G "MinGW Makefiles" ..
+  - cmd: cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DOPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64 -DSUNSHINE_ROOT=. -G "MinGW Makefiles" ..
   - sh: make -j$(nproc)
   - cmd: mingw32-make -j2
+  - cmd: set PATH=%OLDPATH%
+
+after_build:
+  - cmd: 7z a Sunshine-Windows.zip C:\msys64\mingw64\bin\*.dll
+  - cmd: 7z a Sunshine-Windows.zip ..\assets\
+  - cmd: 7z a Sunshine-Windows.zip sunshine.exe
+  - cmd: appveyor PushArtifact Sunshine-Windows.zip


### PR DESCRIPTION
This PR adds a build artifact to the automated Windows builds in AppVeyor which archives a ZIP file which can be used to run Sunshine. This is currently archiving more MinGW DLLs than we need, but it's okay for now.

Example: https://ci.appveyor.com/project/cgutman/sunshine/builds/30248652/job/2kcat46lka747q22/artifacts