### PR TITLE
Retrieve MAC address on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(WIN32)
 		ksuser
 		wsock32
 		ws2_32
+		iphlpapi
 		windowsapp
 		d3d11 dxgi
 		setupapi)


### PR DESCRIPTION
This PR adds support for Wake-on-LAN for Windows hosts by providing the MAC address in the serverinfo response.