### PR TITLE
Fix incorrect key codes

### DIFF
--- a/sunshine/platform/linux_evdev.cpp
+++ b/sunshine/platform/linux_evdev.cpp
@@ -153,11 +153,11 @@ uint16_t keysym(uint16_t modcode) {
     case 0x6B:
       return XK_KP_Add;
     case 0x6C:
-      return XK_KP_Decimal;
+      return XK_KP_Separator;
     case 0x6D:
       return XK_KP_Subtract;
     case 0x6E:
-      return XK_KP_Separator;
+      return XK_KP_Decimal;
     case 0x6F:
       return XK_KP_Divide;
     case 0x90:

--- a/sunshine/platform/windows.cpp
+++ b/sunshine/platform/windows.cpp
@@ -169,12 +169,33 @@ void keyboard(input_t &input, uint16_t modcode, bool release) {
   auto &ki = i.ki;
 
   // For some reason, MapVirtualKey(VK_LWIN, MAPVK_VK_TO_VSC) doesn't seem to work :/
-  if(modcode != VK_LWIN && modcode != VK_RWIN) {
+  if(modcode != VK_LWIN && modcode != VK_RWIN && modcode != VK_PAUSE) {
     ki.wScan = MapVirtualKey(modcode, MAPVK_VK_TO_VSC);
     ki.dwFlags = KEYEVENTF_SCANCODE;
   }
   else {
     ki.wVk = modcode;
+  }
+
+  // https://docs.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#keystroke-message-flags
+  switch(modcode) {
+    case VK_RMENU:
+    case VK_RCONTROL:
+    case VK_INSERT:
+    case VK_DELETE:
+    case VK_HOME:
+    case VK_END:
+    case VK_PRIOR:
+    case VK_NEXT:
+    case VK_UP:
+    case VK_DOWN:
+    case VK_LEFT:
+    case VK_RIGHT:
+    case VK_DIVIDE:
+      ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+      break;
+    default:
+      break;
   }
 
   if(release) {


### PR DESCRIPTION
This PR fixes extended keys not working on Windows (notably the arrow keys) and a couple keys being swapped on the number pad on Linux.