### PR TITLE
Fix row pitch being assumed to be 'width * 4'

### DIFF
--- a/sunshine/platform/common.h
+++ b/sunshine/platform/common.h
@@ -40,6 +40,8 @@ public:
   std::uint8_t *data  {};
   std::int32_t width  {};
   std::int32_t height {};
+  std::int32_t pixel_pitch {};
+  std::int32_t row_pitch {};
 
   img_t() = default;
   img_t(const img_t&) = delete;

--- a/sunshine/platform/windows_dxgi.cpp
+++ b/sunshine/platform/windows_dxgi.cpp
@@ -144,7 +144,7 @@ void blend_cursor_monochrome(const cursor_t &cursor, img_t &img) {
     auto and_mask = &cursor_img_data[i * pitch];
     auto xor_mask = &cursor_img_data[(i + height) * pitch];
 
-    auto img_pixel_p = &img_data[(i + img_skip_y) * img.width + img_skip_x];
+    auto img_pixel_p = &img_data[(i + img_skip_y) * (img.row_pitch / img.pixel_pitch) + img_skip_x];
 
     auto skip_y = cursor_skip_y;
     for(int x = 0; x < bytes_per_row; ++x) {
@@ -198,7 +198,7 @@ void blend_cursor_color(const cursor_t &cursor, img_t &img) {
     auto cursor_begin = &cursor_img_data[i * width + cursor_skip_x];
     auto cursor_end = &cursor_begin[delta_width];
 
-    auto img_pixel_p = &img_data[(i + img_skip_y) * img.width + img_skip_x];
+    auto img_pixel_p = &img_data[(i + img_skip_y) * (img.row_pitch / img.pixel_pitch) + img_skip_x];
     std::for_each(cursor_begin, cursor_end, [&](int cursor_pixel) {
       auto colors_out = (std::uint8_t*)&cursor_pixel;
       auto colors_in  = (std::uint8_t*)img_pixel_p;
@@ -313,6 +313,7 @@ public:
 
       img->width = width;
       img->height = height;
+      img->row_pitch = current_img.RowPitch;
     }
 
     std::copy_n((std::uint8_t*)current_img.pData, height * current_img.RowPitch, (std::uint8_t*)img->data);
@@ -329,6 +330,8 @@ public:
     img->data   = nullptr;
     img->height = 0;
     img->width  = 0;
+    img->row_pitch = 0;
+    img->pixel_pitch = 4;
 
     return img;
   }

--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -46,7 +46,7 @@ void encode(int64_t frame, ctx_t &ctx, sws_t &sws, frame_t &yuv_frame, platf::im
   av_frame_make_writable(yuv_frame.get());
 
   const int linesizes[2] {
-    (int)(img.width * sizeof(int)), 0
+    img.row_pitch, 0
   };
 
   auto data = img.data;


### PR DESCRIPTION
This fixes the bug that Coolykoen reported on Discord where the display was garbled when the Windows host desktop was set to 1366x768. The cause was extra padding that broke the assumption that `row_pitch == 4 * width` (actual row pitch was 5504 instead of 5464). To fix this, I added pitch fields to `img_t` and use those values directly where applicable.