### PR TITLE
Download pre-compiled from GitHub releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,15 @@ if(WIN32)
 	option(SUNSHINE_STANDALONE "Compile stand-alone binary of Sunshine" OFF)
 	#Prebuilt binaries can be found on GitHub releases
 	if(SUNSHINE_STANDALONE)
-		set(SUNSHINE_PREBUILT_VERSION "1.0.0")
-		set(SUNSHINE_PREBUILT_HASH "5d59986bd7f619eaaf82b2dd56b5127b747c9cbe8db61e3b898ff6b485298ed6")
-		download_file("https://github.com/TheElixZammuto/sunshine-prebuilt/releases/download/${SUNSHINE_PREBUILT_VERSION}/pre-compiled.zip" 
-		./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip 
-		SHA256 ${SUNSHINE_PREBUILT_HASH})
-		file(REMOVE_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled")
-		file(ARCHIVE_EXTRACT INPUT ./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled")
+		if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled/windows")
+			message(INFO " Downloading Windows Prebuilts")
+			set(SUNSHINE_PREBUILT_VERSION "1.0.0")
+			set(SUNSHINE_PREBUILT_HASH "5d59986bd7f619eaaf82b2dd56b5127b747c9cbe8db61e3b898ff6b485298ed6")
+			download_file("https://github.com/TheElixZammuto/sunshine-prebuilt/releases/download/${SUNSHINE_PREBUILT_VERSION}/pre-compiled.zip" 
+				./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip 
+				SHA256 ${SUNSHINE_PREBUILT_HASH})
+			file(ARCHIVE_EXTRACT INPUT ./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled")
+		endif()
 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 	
 		if(NOT DEFINED SUNSHINE_PREPARED_BINARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,30 @@ project(Sunshine)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
+function(download_file url filename hash_type hash)
+
+if(NOT EXISTS ${filename})
+  file(DOWNLOAD ${url} ${filename}
+       TIMEOUT 60  # seconds
+       EXPECTED_HASH ${hash_type}=${hash}
+       TLS_VERIFY ON)
+endif()
+
+endfunction(download_file)
+
 # On MSYS2, building a stand-alone binary that links with ffmpeg is not possible,
 # Therefore, ffmpeg, libx264 and libx265 must be build from source
 if(WIN32)
 	option(SUNSHINE_STANDALONE "Compile stand-alone binary of Sunshine" OFF)
+	#Prebuilt binaries can be found on GitHub releases
 	if(SUNSHINE_STANDALONE)
+		set(SUNSHINE_PREBUILT_VERSION "1.0.0")
+		set(SUNSHINE_PREBUILT_HASH "5d59986bd7f619eaaf82b2dd56b5127b747c9cbe8db61e3b898ff6b485298ed6")
+		download_file("https://github.com/TheElixZammuto/sunshine-prebuilt/releases/download/${SUNSHINE_PREBUILT_VERSION}/pre-compiled.zip" 
+		./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip 
+		SHA256 ${SUNSHINE_PREBUILT_HASH})
+		file(REMOVE_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled")
+		file(ARCHIVE_EXTRACT INPUT ./pre-compiled-${SUNSHINE_PREBUILT_VERSION}.zip DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/pre-compiled")
 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 	
 		if(NOT DEFINED SUNSHINE_PREPARED_BINARIES)

--- a/sunshine/main.cpp
+++ b/sunshine/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
   }
 
   if(config::sunshine.min_log_level >= 2) {
-    av_log_set_level(AV_LOG_QUIET);
+    av_log_set_level(AV_LOG_WARNING);
   }
 
   sink = boost::make_shared<text_sink>();


### PR DESCRIPTION
Instead of using Git LFS, let's download the prebuilt for Windows from Github's Releases Function.
