### PR TITLE
corrections made to define actual accepted rc values (needs work)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmake-build-*
 *.kdev4
 
 .idea
+.vscode

--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -175,26 +175,24 @@
 # nv_coder = auto
 
 ##################################### AMD #####################################
-###### presets ###########
+###### quality ###########
 # default
 # speed
 # balanced
 ##########################
-# amd_preset = balanced
+# amd_quality = balanced
 #
 ####### rate control #####
 # auto      -- let ffmpeg decide rate control
-# constqp   -- constant QP mode
-# vbr       -- variable bitrate
-# cbr       -- constant bitrate
-# cbr_hq    -- cbr high quality
-# cbr_ld_hq -- cbr low delay high quality
-# vbr_hq    -- vbr high quality
+# cqp         -- Peak Contrained Variable Bitrate
+# vbr_peak    -- Variable bitrate mode
+# cbr         -- Peak Contrained Variable Bitrate
+# vbr_latency --Latency Constrained Variable Bitrate
 ##########################
 # amd_rc = auto
 
 ###### h264 entropy ######
-# auto -- let ffmpeg nvenc decide the entropy encoding
+# auto -- let ffmpeg amdvce decide the entropy encoding
 # cabac
 # cavlc
 ##########################

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -86,20 +86,29 @@ int coder_from_view(const std::string_view &coder) {
 }
 
 namespace amd {
-enum quality_e : int {
+// enum class quality_h264_e : int {
+//   _default = 0,
+//   balanced = 5,
+//   speed = 10,
+// };
+
+// enum class quality_hevc_e : int {
+//   _default = 2,
+//   balanced = 0,
+//   speed = 1,
+// };
+
+enum  quality_e : int {
   _default = 0,
-  speed,
   balanced,
-  //quality2,
+  speed,
 };
 
 enum rc_e : int {
-  constqp   = 0x0,       /**< Constant QP mode */
-  vbr       = 0x1,       /**< Variable bitrate mode */
-  cbr       = 0x2,       /**< Constant bitrate mode */
-  cbr_ld_hq = 0x8,       /**< low-delay CBR, high quality */
-  cbr_hq    = 0x10,      /**< CBR, high quality (slower) */
-  vbr_hq    = 0x20       /**< VBR, high quality (slower) */
+  cqp         = 0,       /**< Peak Contrained Variable Bitrate */
+  vbr_peak    = 2,       /**< Variable bitrate mode */
+  cbr         = 3,       /**< Peak Contrained Variable Bitrate */
+  vbr_latency = 1,       /**< Latency Constrained Variable Bitrate */
 };
 
 enum coder_e : int {
@@ -108,11 +117,30 @@ enum coder_e : int {
   cavlc
 };
 
+// std::optional<quality_h264_e> quality_from_view_h264(const std::string_view &quality_h264) {
+// #define _CONVERT_(x) if(quality == #x##sv) return x
+//   _CONVERT_(speed);
+//   _CONVERT_(balanced);
+//   // _CONVERT_(best);
+//   if(quality == "default"sv) return _default;
+// #undef _CONVERT_
+//   return std::nullopt;
+// }
+
+// std::optional<quality_hevc_e> quality_from_view_hevc(const std::string_view &quality_hevc) {
+// #define _CONVERT_(x) if(quality == #x##sv) return x
+//   _CONVERT_(speed);
+//   _CONVERT_(balanced);
+//   // _CONVERT_(best);
+//   if(quality == "default"sv) return _default;
+// #undef _CONVERT_
+//   return std::nullopt;
+// }
+
 std::optional<quality_e> quality_from_view(const std::string_view &quality) {
 #define _CONVERT_(x) if(quality == #x##sv) return x
   _CONVERT_(speed);
   _CONVERT_(balanced);
-  //_CONVERT_(quality2);
   if(quality == "default"sv) return _default;
 #undef _CONVERT_
   return std::nullopt;
@@ -120,12 +148,10 @@ std::optional<quality_e> quality_from_view(const std::string_view &quality) {
 
 std::optional<rc_e> rc_from_view(const std::string_view &rc) {
 #define _CONVERT_(x) if(rc == #x##sv) return x
-  _CONVERT_(constqp);
-  _CONVERT_(vbr);
+  _CONVERT_(cqp);
+  _CONVERT_(vbr_peak);
   _CONVERT_(cbr);
-  _CONVERT_(cbr_hq);
-  _CONVERT_(vbr_hq);
-  _CONVERT_(cbr_ld_hq);
+  _CONVERT_(vbr_latency);
 #undef _CONVERT_
   return std::nullopt;
 }
@@ -423,6 +449,8 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   int_f(vars, "nv_rc", video.nv.rc, nv::rc_from_view);
   int_f(vars, "nv_coder", video.nv.coder, nv::coder_from_view);
 
+  // int_f(vars, "amd_quality", video.amd.quality_h264, amd::quality_from_view_h264);
+  // int_f(vars, "amd_quality", video.amd.quality_hevc, amd::quality_from_view_hevc);
   int_f(vars, "amd_quality", video.amd.quality, amd::quality_from_view);
   int_f(vars, "amd_rc", video.amd.rc, amd::rc_from_view);
   int_f(vars, "amd_coder", video.amd.coder, amd::coder_from_view);

--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -61,14 +61,15 @@ enum class profile_hevc_e : int {
 namespace amd {
 
 enum class profile_h264_e : int {
-  main,
-  high,
-  constrained_baseline,
-  constrained_high,
+  main = 77,
+  high = 100,
+  constrained_baseline = 256,
+  constrained_high = 257,
 };
 
-enum class profile_hevc_e : int {
+enum class profile_tier_hevc_e : int {
   main,
+  high,
 };
 }
 
@@ -303,7 +304,7 @@ static encoder_t nvenc {
 
 static encoder_t amdvce {
   "amdvce"sv,
-  { (int)amd::profile_h264_e::high, (int)amd::profile_hevc_e::main },
+  { (int)amd::profile_h264_e::high, (int)amd::profile_tier_hevc_e::high },
   AV_HWDEVICE_TYPE_D3D11VA,
   AV_PIX_FMT_D3D11,
   AV_PIX_FMT_NV12, AV_PIX_FMT_YUV420P,
@@ -373,11 +374,9 @@ static encoder_t software {
 static std::vector<encoder_t> encoders {
 #ifdef _WIN32
   nvenc,
+  amdvce,  
 #endif
   software,
-#ifdef _WIN32
-  amdvce,
-#endif
 };
 
 void reset_display(std::shared_ptr<platf::display_t> &disp, AVHWDeviceType type) {


### PR DESCRIPTION
The RC values for hevc and h264 amf encoders do not have same int values. This rc class need to be made as scoped enumerators so the user can define the same name without worrying about the int value corresponding (which I could not implement but you can see my commended out stuff, I'm no programmer).

h264:
```  
-rc                <int>        E..V...... Set the rate control mode (from -1 to 3) (default -1)
cqp             0            E..V...... Constant Quantization Parameter
cbr             3            E..V...... Constant Bitrate
vbr_peak        2            E..V...... Peak Contrained Variable Bitrate
vbr_latency     1            E..V...... Latency Constrained Variable Bitrate
```

hevc:
```  
-rc                <int>        E..V...... Rate Control Method (from -1 to 3) (default -1)
cqp             0            E..V...... Constant Quantization Parameter
cbr             1            E..V...... Constant Bitrate
vbr_peak        2            E..V...... Peak Contrained Variable Bitrate
vbr_latency     3            E..V...... Latency Constrained Variable Bitrate
```

quality values also need to be made as scoped enumerators since h264 scales from 0 to 2 and hevc scales from 0 to 10

h264:
```
 -quality           <int>        E..V...... Quality Preference (from 0 to 2) (default speed)
     speed           1            E..V...... Prefer Speed
     balanced        0            E..V...... Balanced
     quality         2            E..V...... Prefer Quality
```

hevc:
```
  -quality           <int>        E..V...... Set the encoding quality (from 0 to 10) (default speed)
     balanced        5            E..V......
     speed           10           E..V......
     quality         0            E..V......
```