### PR TITLE
Fix Modifiers stuck on Host On Disconnection

### DIFF
--- a/sunshine/input.cpp
+++ b/sunshine/input.cpp
@@ -402,6 +402,13 @@ void passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&in
   task_pool.push(passthrough_helper, input, util::cmove(input_data));
 }
 
+void reset(){
+    for(auto& kp : key_press){
+      platf::keyboard(platf_input, kp.first & 0x00FF, true);
+      key_press[kp.first] = false;
+    }
+}
+
 void init() {
   platf_input = platf::input();
 }

--- a/sunshine/input.h
+++ b/sunshine/input.h
@@ -11,6 +11,7 @@ namespace input {
 struct input_t;
 
 void print(void *input);
+void reset();
 void passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data);
 
 void init();

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -885,6 +885,8 @@ state_e state(session_t &session) {
 void stop(session_t &session) {
   while_starting_do_nothing(session.state);
 
+  //Reset input on session stop to avoid stuck repeated keys
+  input::reset();
   auto expected = state_e::RUNNING;
   auto already_stopping = !session.state.compare_exchange_strong(expected, state_e::STOPPING);
   if(already_stopping) {

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -884,9 +884,6 @@ state_e state(session_t &session) {
 
 void stop(session_t &session) {
   while_starting_do_nothing(session.state);
-
-  //Reset input on session stop to avoid stuck repeated keys
-  input::reset();
   auto expected = state_e::RUNNING;
   auto already_stopping = !session.state.compare_exchange_strong(expected, state_e::STOPPING);
   if(already_stopping) {
@@ -903,6 +900,9 @@ void join(session_t &session) {
   session.audioThread.join();
   BOOST_LOG(debug) << "Waiting for control to end..."sv;
   session.controlEnd.view();
+  //Reset input on session stop to avoid stuck repeated keys
+  BOOST_LOG(debug) << "Resetting Input..."sv;
+  input::reset();
   BOOST_LOG(debug) << "Session ended"sv;
 }
 


### PR DESCRIPTION
In some cases, when client terminates the session using the CTRL+SHIFT+ALT+Q combination, the server does not handle the released modifiers correctly, and continues to keep them as "pressed". This PR should fix that