### PR TITLE
Force IDR frames for libx265 encoder

### DIFF
--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -315,6 +315,7 @@ static encoder_t software {
     // It also looks like gop_size isn't passed on to x265, so we have to set
     // 'keyint=-1' in the parameters ourselves.
     {
+      { "forced-idr"s, 1 },
       { "x265-params"s, "info=0:keyint=-1"s },
       { "preset"s, &config::video.sw.preset },
       { "tune"s, &config::video.sw.tune } },


### PR DESCRIPTION
Parameter is needed to avoid infinite black screen with
"Waiting for IDR frame" in moonlight-qt (3.1.3) on Windows.

Tested on Windows 10 x64 host with moonlight-qt 3.1.3 Windows 10 x64 client.