### PR TITLE
Video FEC changes

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -83,12 +83,12 @@
 # The file where configuration for the different applications that Sunshine can run during a stream
 # file_apps = apps.json
 
-# How much error correcting packets must be send for every video
-# This is just some random number, don't know the optimal value
-# The higher fec_percentage, the lower space for the actual data to send per frame there is
+# Percentage of error correcting packets per data packet in each video frame
+# Higher values can correct for more network packet loss, but at the cost of increasing bandwidth usage
+# The default value of 20 is what GeForce Experience uses
 #
-# The value must be greater than 0 and lower than or equal to 100
-# fec_percentage = 10
+# The value must be greater than 0 and lower than or equal to 255
+# fec_percentage = 20
 
 # When multicasting, it could be usefull to have different configurations for each connected Client.
 # For example:

--- a/assets/web/config.html
+++ b/assets/web/config.html
@@ -317,12 +317,12 @@
             <!--FEC Percentage-->
             <div class="mb-3">
                 <label for="fec_percentage" class="form-label">FEC Percentage</label>
-                <input type="text" class="form-control" id="fec_percentage" placeholder="10"
+                <input type="text" class="form-control" id="fec_percentage" placeholder="20"
                     v-model="config.fec_percentage">
                 <div class="form-text">
-                    How much error correcting packets must be send for every video.<br>
-                    This is just some random number, don't know the optimal value.<br>
-                    The higher fec_percentage, the lower space for the actual data to send per frame there is
+                    Percentage of error correcting packets per data packet in each video frame.<br>
+                    Higher values can correct for more network packet loss, but at the cost of increasing bandwidth usage.<br>
+                    The default value of 20 is what GeForce Experience uses.
                 </div>
             </div>
             <!--Channels-->

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -180,7 +180,7 @@ stream_t stream {
 
   APPS_JSON_PATH,
 
-  10, // fecPercentage
+  20, // fecPercentage
   1   // channels
 };
 
@@ -624,7 +624,7 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   int_between_f(vars, "channels", stream.channels, { 1, std::numeric_limits<int>::max() });
 
   path_f(vars, "file_apps", stream.file_apps);
-  int_between_f(vars, "fec_percentage", stream.fec_percentage, { 1, 100 });
+  int_between_f(vars, "fec_percentage", stream.fec_percentage, { 1, 255 });
 
   to = std::numeric_limits<int>::min();
   int_f(vars, "back_button_timeout", to);

--- a/sunshine/rtsp.cpp
+++ b/sunshine/rtsp.cpp
@@ -441,6 +441,9 @@ void cmd_announce(rtsp_server_t *server, net::peer_t peer, msg_t &&req) {
   args.try_emplace("x-nv-vqos[0].bitStreamFormat"sv, "0"sv);
   args.try_emplace("x-nv-video[0].dynamicRangeMode"sv, "0"sv);
   args.try_emplace("x-nv-aqos.packetDuration"sv, "5"sv);
+  args.try_emplace("x-nv-general.useReliableUdp"sv, "1"sv);
+  args.try_emplace("x-nv-vqos[0].fec.minRequiredFecPackets"sv, "0"sv);
+  args.try_emplace("x-nv-general.featureFlags"sv, "135"sv);
 
   config_t config;
 
@@ -453,7 +456,10 @@ void cmd_announce(rtsp_server_t *server, net::peer_t peer, msg_t &&req) {
     config.audio.flags[audio::config_t::HIGH_QUALITY] =
       util::from_view(args.at("x-nv-audio.surround.AudioQuality"sv));
 
-    config.packetsize = util::from_view(args.at("x-nv-video[0].packetSize"sv));
+    config.controlProtocolType    = util::from_view(args.at("x-nv-general.useReliableUdp"sv));
+    config.packetsize             = util::from_view(args.at("x-nv-video[0].packetSize"sv));
+    config.minRequiredFecPackets  = util::from_view(args.at("x-nv-vqos[0].fec.minRequiredFecPackets"sv));
+    config.featureFlags           = util::from_view(args.at("x-nv-general.featureFlags"sv));
 
     config.monitor.height         = util::from_view(args.at("x-nv-video[0].clientViewportHt"sv));
     config.monitor.width          = util::from_view(args.at("x-nv-video[0].clientViewportWd"sv));

--- a/sunshine/stream.h
+++ b/sunshine/stream.h
@@ -20,7 +20,11 @@ struct session_t;
 struct config_t {
   audio::config_t audio;
   video::config_t monitor;
+
   int packetsize;
+  int minRequiredFecPackets;
+  int featureFlags;
+  int controlProtocolType;
 
   std::optional<int> gcmap;
 };


### PR DESCRIPTION
This PR increases the default FEC percentage to 20% to match GFE.

It also introduces support for the `x-nv-vqos[0].fec.minRequiredFecPackets`  attribute added in GFE 3.22. This enables clients to specify a minimum number of FEC shards per frame. If that minimum is not met, the FEC percentage is increased for that frame to meet the FEC shard minimum (even up to 200% for a single data shard frame). Like #112, Sunshine needs to start advertising a higher `appversion` for Moonlight to use this feature out of the box.

I also included parsing of some additional SDP attributes which will be required to support the encrypted control stream and encrypted audio which is required to advertise GFE 3.22 compliance.