### PR TITLE
Fix IDR frame delays after packet loss or client request

### DIFF
--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -1025,22 +1025,14 @@ void encode_run(
         return;
       }
 
-      auto end     = event->second;
-      frame_nr     = end;
-      key_frame_nr = end + config.framerate;
-    }
-    else if(frame_nr == key_frame_nr) {
-      auto frame = session->device->frame;
-
-      frame->pict_type = AV_PICTURE_TYPE_I;
-      frame->key_frame = 1;
+      key_frame_nr = frame_nr;
     }
 
     std::this_thread::sleep_until(next_frame);
     next_frame += delay;
 
     // When Moonlight request an IDR frame, send frames even if there is no new captured frame
-    if(frame_nr > key_frame_nr || images->peek()) {
+    if(!frame->key_frame || images->peek()) {
       if(auto img = images->pop(delay)) {
         session->device->convert(*img);
       }


### PR DESCRIPTION
The current IDR frame logic sets `key_frame_nr` to a full second worth of frames in the future and actually causes 2 IDR frames to be sent for each request (once in the `idr_events->peek()` case and once `config.framerate` frames later when `frame_nr == key_frame_nr`). It also causes the `frame_nr` to potentially go backwards, leading to valid frames being discarded (which may be the original reason for the `key_frame_nr = end + config.framerate` hack).

All these bugs lead to spurious poor connection warnings in Moonlight (particularly apparent when first establishing a connection with Moonlight Qt) and poor responsiveness on lossy networks due to significant delays on IDR frames. Performance with modest packet loss (simulated using Clumsy network conditioner) is massively improved with these changes.