### PR TITLE
Remove super key workaround

### DIFF
--- a/sunshine/platform/linux/input.cpp
+++ b/sunshine/platform/linux/input.cpp
@@ -290,8 +290,8 @@ uint16_t keysym(uint16_t modcode) {
     return XK_Control_R;
   case 0xA4:
     return XK_Alt_L;
-  case 0xA5: /* return XK_Alt_R; */
-    return XK_Super_L;
+  case 0xA5:
+    return XK_Alt_R;
   case 0x5B:
     return XK_Super_L;
   case 0x5C:

--- a/sunshine/platform/windows/input.cpp
+++ b/sunshine/platform/windows/input.cpp
@@ -201,10 +201,6 @@ void scroll(input_t &input, int distance) {
 }
 
 void keyboard(input_t &input, uint16_t modcode, bool release) {
-  if(modcode == VK_RMENU) {
-    modcode = VK_LWIN;
-  }
-
   INPUT i {};
   i.type   = INPUT_KEYBOARD;
   auto &ki = i.ki;


### PR DESCRIPTION
Since Moonlight can pass the Super key now with the "Capture system keyboard shortcuts" option, the old workaround of mapping right Alt to the Super key is no longer required. This allows the right Alt key to be used by applications/games.