### PR TITLE
Add basic NVENC support on Linux

### DIFF
--- a/assets/web/config.html
+++ b/assets/web/config.html
@@ -528,7 +528,7 @@
                 }
                 if (this.platform == "linux") {
                     this.tabs = this.tabs.filter(el => {
-                        return el.id !== "nv" && el.id !== "amd";
+                        return el.id !== "amd";
                     });
                 }
 

--- a/sunshine/platform/common.h
+++ b/sunshine/platform/common.h
@@ -75,6 +75,7 @@ enum class mem_type_e {
   system,
   vaapi,
   dxgi,
+  cuda,
   unknown
 };
 

--- a/sunshine/platform/linux/display.cpp
+++ b/sunshine/platform/linux/display.cpp
@@ -372,7 +372,7 @@ struct shm_attr_t : public x11_attr_t {
 };
 
 std::shared_ptr<display_t> display(platf::mem_type_e hwdevice_type) {
-  if(hwdevice_type != platf::mem_type_e::system && hwdevice_type != platf::mem_type_e::vaapi) {
+  if(hwdevice_type != platf::mem_type_e::system && hwdevice_type != platf::mem_type_e::vaapi && hwdevice_type != platf::mem_type_e::cuda) {
     BOOST_LOG(error) << "Could not initialize display with the given hw device type."sv;
     return nullptr;
   }

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -410,11 +410,14 @@ std::vector<uint8_t> replace(const std::string_view &original, const std::string
   std::vector<uint8_t> replaced;
 
   auto begin = std::begin(original);
-  auto next  = std::search(begin, std::end(original), std::begin(old), std::end(old));
+  auto end   = std::end(original);
+  auto next  = std::search(begin, end, std::begin(old), std::end(old));
 
   std::copy(begin, next, std::back_inserter(replaced));
-  std::copy(std::begin(_new), std::end(_new), std::back_inserter(replaced));
-  std::copy(next + old.size(), std::end(original), std::back_inserter(replaced));
+  if(next != end) {
+    std::copy(std::begin(_new), std::end(_new), std::back_inserter(replaced));
+    std::copy(next + old.size(), end, std::back_inserter(replaced));
+  }
 
   return replaced;
 }

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -674,7 +674,7 @@ void videoBroadcastThread(udp::socket &sock) {
           video_packet->packet.flags |= FLAG_EOF;
         }
 
-        video_packet->rtp.header         = FLAG_EXTENSION;
+        video_packet->rtp.header         = 0x80 | FLAG_EXTENSION;
         video_packet->rtp.sequenceNumber = util::endian::big<uint16_t>(lowseq + fecIndex);
       });
 
@@ -691,7 +691,7 @@ void videoBroadcastThread(udp::socket &sock) {
 
       inspect->packet.frameIndex = packet->pts;
 
-      inspect->rtp.header         = FLAG_EXTENSION;
+      inspect->rtp.header         = 0x80 | FLAG_EXTENSION;
       inspect->rtp.sequenceNumber = util::endian::big<uint16_t>(lowseq + x);
     }
 


### PR DESCRIPTION
We're not offloading scaling and YUV conversion from the CPU yet, so the gains aren't as high as one of the fully accelerated backends like Windows NVENC or Linux VAAPI.

Still, offloading the H.264/HEVC encoding itself is an improvement over doing everything on the CPU (especially for HEVC).

Partially fixes #45 