### PR TITLE
Increase default ping timeout to 10 seconds

### DIFF
--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -78,7 +78,7 @@
 # ]
 
 # How long to wait in milliseconds for data from moonlight before shutting down the stream
-# ping_timeout = 2000
+# ping_timeout = 10000
 
 # The file where configuration for the different applications that Sunshine can run during a stream
 # file_apps = apps.json

--- a/assets/web/config.html
+++ b/assets/web/config.html
@@ -55,7 +55,7 @@
             <!--Ping Timeout-->
             <div class="mb-3">
                 <label for="ping_timeout" class="form-label">Ping Timeout</label>
-                <input type="text" class="form-control" id="ping_timeout" placeholder="2000"
+                <input type="text" class="form-control" id="ping_timeout" placeholder="10000"
                     v-model="config.ping_timeout">
                 <div class="form-text">How long to wait in milliseconds for data from moonlight before shutting down the
                     stream</div>

--- a/sunshine/config.cpp
+++ b/sunshine/config.cpp
@@ -176,7 +176,7 @@ video_t video {
 audio_t audio {};
 
 stream_t stream {
-  2s, // ping_timeout
+  10s, // ping_timeout
 
   APPS_JSON_PATH,
 


### PR DESCRIPTION
During periods of poor connectivity, the ping timeout of 2 seconds
can easily be exceeded, especially with ENet's RTO backoff logic.

This causes an unnecessary disconnection when the connection would
have recovered on its own in a few seconds. Increasing the timeout
to 10 seconds should prevent spurious disconnections in most cases.

A 10 second timeout is also what GeForce Experience also uses.