### PR TITLE
Reduce CPU usage with Linux NVENC

### DIFF
--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -409,11 +409,13 @@ static encoder_t nvenc {
 #ifdef _WIN32
   AV_HWDEVICE_TYPE_D3D11VA,
   AV_PIX_FMT_D3D11,
+  AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
 #else
   AV_HWDEVICE_TYPE_CUDA,
   AV_PIX_FMT_CUDA,
+  // Fully planar YUV formats are more efficient for sws_scale()
+  AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV420P10,
 #endif
-  AV_PIX_FMT_NV12, AV_PIX_FMT_P010,
   {
     {
       { "forced-idr"s, 1 },


### PR DESCRIPTION
The internal assembly routines inside libswscale perform the RGB->YUV conversion using a fully planar output format, then have to perform an additional YUV420->NV12 conversion step.

NVENC can directly consume YUV420 input frames, so we can completely avoid this NV12 conversion and save quite a bit of CPU time in the process.

Using YUV420 directly allows us to completely get rid of the yuv2nv12 function which was at the top of the performance charts for cycles spent on the entire system while streaming.

NV12 (before):
![nv12](https://user-images.githubusercontent.com/2695644/125169947-22205e00-e172-11eb-9a60-cd80f84bbafb.png)

YUV420 (after):
![yuv420](https://user-images.githubusercontent.com/2695644/125169943-1cc31380-e172-11eb-8db1-acb089694011.png)