### PR TITLE
Fix X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE error with some embedded clients

### DIFF
--- a/sunshine/crypto.cpp
+++ b/sunshine/crypto.cpp
@@ -52,9 +52,13 @@ const char *cert_chain_t::verify(x509_t::element_type *cert) {
       X509_STORE_CTX_cleanup(_cert_ctx.get());
     });
 
-    X509_STORE_CTX_init(_cert_ctx.get(), x509_store.get(), nullptr, nullptr);
+    X509_STORE_CTX_init(_cert_ctx.get(), x509_store.get(), cert, nullptr);
     X509_STORE_CTX_set_verify_cb(_cert_ctx.get(), openssl_verify_cb);
-    X509_STORE_CTX_set_cert(_cert_ctx.get(), cert);
+
+    // We don't care to validate the entire chain for the purposes of client auth.
+    // Some versions of clients forked from Moonlight Embedded produce client certs
+    // that OpenSSL doesn't detect as self-signed due to some X509v3 extensions.
+    X509_STORE_CTX_set_flags(_cert_ctx.get(), X509_V_FLAG_PARTIAL_CHAIN);
 
     auto err = X509_verify_cert(_cert_ctx.get());
 


### PR DESCRIPTION
Passing `X509_V_FLAG_PARTIAL_CHAIN` allows client certificates generated by Moonlight Embedded (and clients using the same cert generation code, like Moonlight Wii U, Moonlight Vita, etc.) to be accepted by Sunshine.

It appears the addition of the X509v3 SKID extension is confusing OpenSSL into thinking it's not a self-signed certification, which triggers the `X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE` error. I was never able to reproduce this myself (might be related to OpenSSL versions), but the [moonlight-wiiu](https://github.com/GaryOderNichts/moonlight-wiiu) developer did and confirmed this fixes it.

Fixes #132
Fixes #134
