### PR TITLE
Reduce CPU usage

### DIFF
--- a/sunshine/platform/linux/kmsgrab.cpp
+++ b/sunshine/platform/linux/kmsgrab.cpp
@@ -649,6 +649,7 @@ public:
         std::this_thread::sleep_for((next_frame - now) / 3 * 2);
       }
       while(next_frame > now) {
+        std::this_thread::sleep_for(1ns);
         now = std::chrono::steady_clock::now();
       }
       next_frame = now + delay;
@@ -769,6 +770,7 @@ public:
         std::this_thread::sleep_for((next_frame - now) / 3 * 2);
       }
       while(next_frame > now) {
+        std::this_thread::sleep_for(1ns);
         now = std::chrono::steady_clock::now();
       }
       next_frame = now + delay;

--- a/sunshine/stream.cpp
+++ b/sunshine/stream.cpp
@@ -763,7 +763,7 @@ void controlBroadcastThread(control_server_t *server) {
       break;
     }
 
-    server->iterate(50ms);
+    server->iterate(500ms);
   }
 
   // Let all remaining connections know the server is shutting down


### PR DESCRIPTION
With this patch (and vaapi + kmsgrab) CPU usage on my system dropped from 60% to 6% when streaming.

I guess the busy wait in capture is there because the sleep will end up sleeping for more than the specified duration?
On my system, on average, it would "oversleep" the next_frame time by:
```
busy wait = ~0.0005ms
1ns sleep = ~0.09ms
```

As this is way under 1ms, it should be more than enough for this use-case. Alternatively, it may be possible to improve it with changing the capture thread scheduling. 

As for the control broadcast thread, I think there is no reason at all to iterate that often?