### PR TITLE
libcap-dev is associated to libcap2

### DIFF
--- a/gen-deb.in
+++ b/gen-deb.in
@@ -38,7 +38,7 @@ Architecture: amd64
 Maintainer: @loki
 Priority: optional
 Version: 0.10.2
-Depends: libssl1.1, libavdevice58, libboost-thread1.67.0 | libboost-thread1.71.0, libboost-filesystem1.67.0 | libboost-filesystem1.71.0, libboost-log1.67.0 | libboost-log1.71.0, libpulse0, libopus0, libxcb-shm0, libxcb-xfixes0, libxtst6, libevdev2, libdrm2, libcap
+Depends: libssl1.1, libavdevice58, libboost-thread1.67.0 | libboost-thread1.71.0, libboost-filesystem1.67.0 | libboost-filesystem1.71.0, libboost-log1.67.0 | libboost-log1.71.0, libpulse0, libopus0, libxcb-shm0, libxcb-xfixes0, libxtst6, libevdev2, libdrm2, libcap2
 Description: Gamestream host for Moonlight
 EOF
 


### PR DESCRIPTION
The deb package does not install due to libcap not existing. The lib is called libcap2 now.