### PR TITLE
Added support for defining app box art

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ All shortcuts start with CTRL + ALT + SHIFT, just like Moonlight
 			- If it fails, Sunshine is terminated
 	- cmd <optional>: The main application
 		- If not specified, a processs is started that sleeps indefinitely
+	- box-art-path: The box art you wish to be displayed for the app.
+		- If not specificed, a fallback image is used.
+		- It is recommended that your box art aspect ratio be 3:4 and you should only use PNG or JPG/JPEG images.
 
 1. When an application is started, if there is an application already running, it will be terminated.
 2. When the application has been shutdown, the stream shuts down as well.
@@ -197,7 +200,8 @@ Linux
 
 		"output":"steam.txt",
 		"cmd":"steam -bigpicture",
-		"prep-cmd":[]
+		"prep-cmd":[],
+		"box-art-path": "/absolute/path/to/your/box/art.png"
 	}
 	]
 }

--- a/assets/web/apps.html
+++ b/assets/web/apps.html
@@ -166,6 +166,22 @@
           If not set, Sunshine will default to the parent directory of the command
         </div>
       </div>
+      <div class="mb-3">
+        <label for="appBoxArt" class="form-label">Box Art</label>
+        <input
+          type="text"
+          class="form-control monospace"
+          id="appBoxArt"
+          aria-describedby="appBoxArtHelp"
+          v-model="editForm['box-art-path']"
+        />
+        <div id="appBoxArtHelp" class="form-text">
+          The absolute path to the box art you wish to associate with this application.
+          The box art you provide should have an aspect ratio of 3:4 and be a PNG or JPG/JPEG; 
+          other image formats have not been tested.
+          If not set, the client connecting to Sunshine will use a placeholder image for the box art.
+        </div>
+      </div>
       <!--buttons-->
       <div class="d-flex">
         <button @click="showEditForm = false" class="btn btn-secondary m-2">
@@ -208,6 +224,7 @@
           index: -1,
           "prep-cmd": [],
           detached: [],
+          "box-art-path": "",
         };
         this.editForm.index = -1;
         this.showEditForm = true;

--- a/sunshine/nvhttp.cpp
+++ b/sunshine/nvhttp.cpp
@@ -764,9 +764,18 @@ void cancel(resp_https_t response, req_https_t request) {
 void appasset(resp_https_t response, req_https_t request) {
   print_req<SimpleWeb::HTTPS>(request);
 
-  std::ifstream in(SUNSHINE_ASSETS_DIR "/box.png");
-  response->write(SimpleWeb::StatusCode::success_ok, in);
   response->close_connection_after_response = true;
+  auto args = request->parse_query_string();
+  
+  if(args.find("appid"s) == std::end(args)) {
+    std::ifstream in(SUNSHINE_ASSETS_DIR "box.png");
+    response->write(SimpleWeb::StatusCode::success_ok, in);
+  }
+  
+  auto appid = util::from_view(args.at("appid")) - 1;
+
+  std::ifstream in(proc::proc.get_apps().at(appid).box_art_path);
+  response->write(SimpleWeb::StatusCode::success_ok, in);
 }
 
 void start() {

--- a/sunshine/nvhttp.cpp
+++ b/sunshine/nvhttp.cpp
@@ -768,7 +768,7 @@ void appasset(resp_https_t response, req_https_t request) {
   auto args = request->parse_query_string();
   
   if(args.find("appid"s) == std::end(args)) {
-    std::ifstream in(SUNSHINE_ASSETS_DIR "box.png");
+    std::ifstream in(SUNSHINE_ASSETS_DIR "/box.png");
     response->write(SimpleWeb::StatusCode::success_ok, in);
   }
   

--- a/sunshine/process.cpp
+++ b/sunshine/process.cpp
@@ -280,6 +280,7 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
       auto name               = parse_env_val(this_env, app_node.get<std::string>("name"s));
       auto cmd                = app_node.get_optional<std::string>("cmd"s);
       auto working_dir        = app_node.get_optional<std::string>("working-dir"s);
+      auto box_art_path       = app_node.get_optional<std::string>("box-art-path"s);
 
       std::vector<proc::cmd_t> prep_cmds;
       if(prep_nodes_opt) {
@@ -319,6 +320,10 @@ std::optional<proc::proc_t> parse(const std::string &file_name) {
 
       if(working_dir) {
         ctx.working_dir = parse_env_val(this_env, *working_dir);
+      }
+
+      if(box_art_path) {
+        ctx.box_art_path = parse_env_val(this_env, *box_art_path);
       }
 
       ctx.name      = std::move(name);

--- a/sunshine/process.h
+++ b/sunshine/process.h
@@ -35,10 +35,11 @@ struct cmd_t {
  *    No session is running and a different set of commands it to be executed
  *    Command exits
  * working_dir -- the process working directory. This is required for some games to run properly.
- * cmd_output --
+ * output --
  *    empty    -- The output of the commands are appended to the output of sunshine
  *    "null"   -- The output of the commands are discarded
  *    filename -- The output of the commands are appended to filename
+ * box_art_path -- absolute path for box art. This is optional.
  */
 struct ctx_t {
   std::vector<cmd_t> prep_cmds;
@@ -55,6 +56,7 @@ struct ctx_t {
   std::string cmd;
   std::string working_dir;
   std::string output;
+  std::string box_art_path;
 };
 
 class proc_t {


### PR DESCRIPTION
* Updated `apps.html` to have a new input for box art path.
    * In the future it should probably upload the art as a blob for separate cache storage, maybe even use a Vue.js cropping library to help enforce the aspect ratio.
* Updated `nvhttp.cpp#appasset` to send over box art if set for requested app.
    * Since app ids are enumerated at runtime this may lead to the box art getting mismatched should the user delete or reorder the json entries.
* Updated `ctx_t` in `process.cpp` / `process.h` to include `box_art_path`.
* Updated related documentation.