### PR TITLE
Add non US Backslash for international keyboards on Linux

### DIFF
--- a/sunshine/platform/linux/input.cpp
+++ b/sunshine/platform/linux/input.cpp
@@ -51,8 +51,8 @@ struct keycode_t {
 
 constexpr auto UNKNOWN = 0;
 
-static constexpr std::array<keycode_t, 0xDF> init_keycodes() {
-  std::array<keycode_t, 0xDF> keycodes {};
+static constexpr std::array<keycode_t, 0xE3> init_keycodes() {
+  std::array<keycode_t, 0xE3> keycodes {};
 
 #define __CONVERT(wincode, linuxcode, scancode)                                       \
   static_assert(wincode < keycodes.size(), "Keycode doesn't fit into keycode array"); \
@@ -182,6 +182,7 @@ static constexpr std::array<keycode_t, 0xDF> init_keycodes() {
   __CONVERT(0xDC /* VKEY_OEM_5 */, KEY_BACKSLASH, 0x70031);
   __CONVERT(0xDD /* VKEY_OEM_6 */, KEY_RIGHTBRACE, 0x70030);
   __CONVERT(0xDE /* VKEY_OEM_7 */, KEY_APOSTROPHE, 0x70034);
+  __CONVERT(0xE2 /* VKEY_NON_US_BACKSLASH */, KEY_102ND, 0x70064);
 #undef __CONVERT
 
   return keycodes;


### PR DESCRIPTION
Currently there is a key on my QWERTZ-Layout that is not recognized at all by sunshine, responsible for <, | and >. 
This Key is basically an additional key to the normal QWERTY Layout, making it one key bigger than the US Keyboard. 
What follows is the way I extracted the information and applied it, just in case somebody wants to add something similar and has no idea where to start (as I had).

First, what is sent to sunshine by moonlight can be looked at here
https://github.com/moonlight-stream/moonlight-qt/blob/51b5f8046f1864e36cfa6efefbe2de71ef98ca92/app/streaming/input/keyboard.cpp#L211 
So one can actually compare what is sent to what is recognized when received. Sunshine manually goes through ALL keys line by line here https://github.com/moonlight-stream/moonlight-qt/blob/51b5f8046f1864e36cfa6efefbe2de71ef98ca92/app/streaming/input/keyboard.cpp#L211 so simply look for whats missing. For what I've found everything is recognized now that is remotely interesting (stuff like multimedia keys seem are ignored), but if anyones interested, the non-accepted keycodes are
```
0x2B
0xA6
0xA7
0xA8
0xA9
0xAA
0xAB
0xAC
```
and, prior to this commit, of course `E2`.
For checking if the key is actually the one your missing, use `xev` and type your key. The **keycode** should match.
Now to add the key, we need not only the keycode, but also the scancode and the keyname. Both can be identified by using `sudo evtest` and typing with the selected (hardware, as the virtual one from sunshine doesnt translate them) keyboard, the **value** in the first line is the is the scancode, the brackets after the **code** in the second line contain the name of the key. The latter can be checked against the file /usr/include/linux/input-event-codes.h, where those names will be translated to internal Linux Code. 
With this info, you can now add an additional **__CONVERT** line. You may have to expand the array keycodes in https://github.com/loki-47-6F-64/sunshine/blob/master/sunshine/platform/linux/input.cpp#L54 so it can include the line. Building sunshine will throw errors at you otherwise. 