### PR TITLE
platform/windows: release frame early during mouse movement

### DIFF
--- a/sunshine/platform/windows/display_base.cpp
+++ b/sunshine/platform/windows/display_base.cpp
@@ -59,9 +59,10 @@ capture_e duplication_t::release_frame() {
   case DXGI_ERROR_WAIT_TIMEOUT:
     return capture_e::timeout;
   case WAIT_ABANDONED:
-  case DXGI_ERROR_ACCESS_LOST:
+  case DXGI_ERROR_INVALID_CALL:
   case DXGI_ERROR_ACCESS_DENIED:
     has_frame = false;
+  case DXGI_ERROR_ACCESS_LOST:
     return capture_e::reinit;
   default:
     BOOST_LOG(error) << "Couldn't release frame [0x"sv << util::hex(status).to_string_view();

--- a/sunshine/platform/windows/display_ram.cpp
+++ b/sunshine/platform/windows/display_ram.cpp
@@ -181,9 +181,11 @@ capture_e display_ram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<::
     case platf::capture_e::error:
       return status;
     case platf::capture_e::timeout:
+      dup.release_frame();
       std::this_thread::sleep_for(1ms);
       continue;
     case platf::capture_e::ok:
+      dup.release_frame();
       img = snapshot_cb(img);
       break;
     default:

--- a/sunshine/platform/windows/display_vram.cpp
+++ b/sunshine/platform/windows/display_vram.cpp
@@ -579,9 +579,11 @@ capture_e display_vram_t::capture(snapshot_cb_t &&snapshot_cb, std::shared_ptr<:
     case platf::capture_e::error:
       return status;
     case platf::capture_e::timeout:
+      dup.release_frame();
       std::this_thread::sleep_for(1ms);
       continue;
     case platf::capture_e::ok:
+      dup.release_frame();
       img = snapshot_cb(img);
       break;
     default:


### PR DESCRIPTION
Resolves visual stutter during mouse movement in certain applications.

Proposed resolution for: #227 

It seems that waiting for the frame to be released between consecutive `snapshot` functions calls introduces visual stutter (only in certain applications & during mouse movement - see above linked issue). This may not be the ideal way to implement the fix, so feedback is appreciated.