### PR TITLE
video: use a better vbv-bufsize & correct software bitrate calculation

### DIFF
--- a/sunshine/video.cpp
+++ b/sunshine/video.cpp
@@ -930,9 +930,9 @@ std::optional<session_t> make_session(const encoder_t &encoder, const config_t &
   }
 
   if(video_format[encoder_t::CBR]) {
-    auto bitrate        = config.bitrate * 1000;
+    auto bitrate        = config.bitrate * (hardware ? 1000 : 800); // software bitrate overshoots by ~20%
     ctx->rc_max_rate    = bitrate;
-    ctx->rc_buffer_size = bitrate / config.framerate;
+    ctx->rc_buffer_size = bitrate / 10;
     ctx->bit_rate       = bitrate;
     ctx->rc_min_rate    = bitrate;
   }


### PR DESCRIPTION
* Increase vbv-bufsize to 1/10 of requested bitrate. The previous value
  was too low, which was resulting in poor encoding quality and failure to
  stabilize at the requested bitrate. Setting to 1/10 of bitrate is a
  good compromise, as it avoids quality loss but also prevents bandwidth
  spikes far above the bitrate/vbv-maxrate.
* With vbv-bufsize set to a more appropriate value, testing shows that
  the average bitrate vs client-requested bandwidth overshoots by ~20%.
  Adjust for this scenario in the software encoding case only.

--

This change greatly increases stream quality on my system. Before the vbv-bufsize change, there would be consistently blurry details for complex or dark scenes (such as foliage or details on far away rocks), especially during movement. Additionally, monitoring of incoming bandwidth to the moonlight-qt client showed a consistent failure to reach the requested bandwidth for intensive scenes.

With the patch, complex details are much better preserved, and the client bandwidth consistently stays at the requested bitrate (which was overshooting by 20%) for intensive scenes. I tested various resolutions and bitrate combinations to ensure the adjusted vbv-bufsize value was not causing vbv-maxrate to be exceeded.